### PR TITLE
feature/cp-371 : getSelectedPaymentMethod, PaymentWidgetAndroidSDK.error 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.12 (2023.09.26)
+## Added
+### 고객이 선택한 결제수단 반환
+com.tosspayments.paymentsdk.PaymentWidget.getSelectedPaymentMethod(): SelectedPaymentMethod
+
+### 위젯 렌더링 status listener에 onFail 메서드 추가
+com.tosspayments.paymentsdk.model.PaymentWidgetStatusListener.onFail(fail: TossPaymentResult.Fail)
+
+| Parameter | Description |
+|-----------|-------------|
+| fail      | 에러 정보       |
+
 # 0.1.11 (2023.07.26)
 ## Fixed
 ### 결제 위젯에서 발생하는 Error Event 수신이 안되는 이슈 수정

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.12 (2023.09.26)
+# 0.1.12 (2023.10.06)
 ## Added
 ### 고객이 선택한 결제수단 반환
 com.tosspayments.paymentsdk.PaymentWidget.getSelectedPaymentMethod(): SelectedPaymentMethod

--- a/app/src/main/java/com/tosspayments/paymentsdk/sample/activity/PaymentWidgetActivity.kt
+++ b/app/src/main/java/com/tosspayments/paymentsdk/sample/activity/PaymentWidgetActivity.kt
@@ -60,11 +60,25 @@ class PaymentWidgetActivity : AppCompatActivity() {
             Log.d(TAG, message)
             binding.paymentMethodWidgetStatus.text = message
         }
+
+        override fun onFail(fail: TossPaymentResult.Fail) {
+            val message = fail.errorMessage
+
+            Log.d(TAG, message)
+            binding.paymentMethodWidgetStatus.text = message
+        }
     }
 
     private val agreementWidgetStatusListener = object : PaymentWidgetStatusListener {
         override fun onLoad() {
             val message = "Agreements loaded"
+
+            Log.d(TAG, message)
+            binding.agreementWidgetStatus.text = message
+        }
+
+        override fun onFail(fail: TossPaymentResult.Fail) {
+            val message = fail.errorMessage
 
             Log.d(TAG, message)
             binding.agreementWidgetStatus.text = message

--- a/app/src/main/java/com/tosspayments/paymentsdk/sample/activity/PaymentWidgetActivity.kt
+++ b/app/src/main/java/com/tosspayments/paymentsdk/sample/activity/PaymentWidgetActivity.kt
@@ -9,6 +9,7 @@ import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.tosspayments.paymentsdk.PaymentWidget
+import com.tosspayments.paymentsdk.TossPayments
 import com.tosspayments.paymentsdk.model.*
 import com.tosspayments.paymentsdk.sample.R
 import com.tosspayments.paymentsdk.sample.databinding.ActivityPaymentWidgetBinding
@@ -62,10 +63,17 @@ class PaymentWidgetActivity : AppCompatActivity() {
         }
 
         override fun onFail(fail: TossPaymentResult.Fail) {
-            val message = fail.errorMessage
-
-            Log.d(TAG, message)
-            binding.paymentMethodWidgetStatus.text = message
+            startActivity(
+                PaymentResultActivity.getIntent(
+                    this@PaymentWidgetActivity,
+                    false,
+                    arrayListOf(
+                        "ErrorCode|${fail.errorCode}",
+                        "ErrorMessage|${fail.errorMessage}",
+                        "OrderId|${fail.orderId}"
+                    )
+                )
+            )
         }
     }
 

--- a/app/src/main/java/com/tosspayments/paymentsdk/sample/activity/PaymentWidgetActivity.kt
+++ b/app/src/main/java/com/tosspayments/paymentsdk/sample/activity/PaymentWidgetActivity.kt
@@ -9,7 +9,6 @@ import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.tosspayments.paymentsdk.PaymentWidget
-import com.tosspayments.paymentsdk.TossPayments
 import com.tosspayments.paymentsdk.model.*
 import com.tosspayments.paymentsdk.sample.R
 import com.tosspayments.paymentsdk.sample.databinding.ActivityPaymentWidgetBinding
@@ -63,6 +62,7 @@ class PaymentWidgetActivity : AppCompatActivity() {
         }
 
         override fun onFail(fail: TossPaymentResult.Fail) {
+            Log.d(TAG, fail.errorMessage)
             startActivity(
                 PaymentResultActivity.getIntent(
                     this@PaymentWidgetActivity,
@@ -86,10 +86,18 @@ class PaymentWidgetActivity : AppCompatActivity() {
         }
 
         override fun onFail(fail: TossPaymentResult.Fail) {
-            val message = fail.errorMessage
-
-            Log.d(TAG, message)
-            binding.agreementWidgetStatus.text = message
+            Log.d(TAG, fail.errorMessage)
+            startActivity(
+                PaymentResultActivity.getIntent(
+                    this@PaymentWidgetActivity,
+                    false,
+                    arrayListOf(
+                        "ErrorCode|${fail.errorCode}",
+                        "ErrorMessage|${fail.errorMessage}",
+                        "OrderId|${fail.orderId}"
+                    )
+                )
+            )
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
-versionName=0.1.11
+versionName=0.1.12

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
@@ -24,6 +24,7 @@ class PaymentWidget(
 ) {
     private val tossPayments: TossPayments = TossPayments(clientKey)
     private val redirectUrl = paymentOptions?.brandPayOption?.redirectUrl
+    private var selectedPaymentMethod: SelectedPaymentMethod? = null
 
     private val domain = try {
         if (!redirectUrl.isNullOrBlank()) {
@@ -72,6 +73,11 @@ class PaymentWidget(
             }
             PaymentMethod.EVENT_NAME_CUSTOM_METHOD_UNSELECTED -> {
                 paymentMethodEventListener?.onCustomPaymentMethodUnselected(paymentMethodKey)
+            }
+            PaymentMethod.EVENT_NAME_CHANGE_PAYMENT_METHOD -> {
+                kotlin.runCatching { SelectedPaymentMethod.fromJson(params) }.getOrNull()?.let {
+                    selectedPaymentMethod = it
+                }
             }
             Agreement.EVENT_NAME_UPDATE_AGREEMENT_STATUS -> {
                 kotlin.runCatching { AgreementStatus.fromJson(params) }.getOrNull()?.let {
@@ -171,6 +177,15 @@ class PaymentWidget(
             domain,
             redirectUrl
         )
+    }
+
+    /**
+     * 고객이 선택한 결제수단
+     * @since TODO
+     */
+    @Throws(IllegalAccessException::class)
+    fun getSelectedPaymentMethod(): SelectedPaymentMethod {
+        return this.selectedPaymentMethod ?: throw IllegalAccessException(PaymentMethod.MESSAGE_NOT_RENDERED)
     }
 
     /**

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
@@ -188,7 +188,7 @@ class PaymentWidget(
 
     /**
      * 고객이 선택한 결제수단
-     * @since TODO
+     * @since 2023/10/06
      */
     @Throws(IllegalAccessException::class)
     fun getSelectedPaymentMethod(): SelectedPaymentMethod {

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
@@ -104,6 +104,11 @@ class PaymentWidget(
                     )
                 }
             }
+
+            @JavascriptInterface
+            fun error(errorCode: String, message: String, orderId: String?) {
+                methodWidget?.onFail(TossPaymentResult.Fail(errorCode, message, orderId))
+            }
         }
 
     private var methodWidget: PaymentMethod? = null

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/PaymentWidget.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import android.webkit.JavascriptInterface
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -77,6 +78,7 @@ class PaymentWidget(
             PaymentMethod.EVENT_NAME_CHANGE_PAYMENT_METHOD -> {
                 kotlin.runCatching { SelectedPaymentMethod.fromJson(params) }.getOrNull()?.let {
                     selectedPaymentMethod = it
+                    Log.d("selectedPaymentMethod", it.toString())
                 }
             }
             Agreement.EVENT_NAME_UPDATE_AGREEMENT_STATUS -> {

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/PaymentWidgetStatusListener.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/PaymentWidgetStatusListener.kt
@@ -2,4 +2,6 @@ package com.tosspayments.paymentsdk.model
 
 interface PaymentWidgetStatusListener {
     fun onLoad()
+
+    fun onFail(fail: TossPaymentResult.Fail)
 }

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/SelectedPaymentMethod.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/SelectedPaymentMethod.kt
@@ -1,0 +1,41 @@
+package com.tosspayments.paymentsdk.model
+
+import android.util.Log
+import org.json.JSONObject
+
+data class SelectedPaymentMethod(
+    val type: String,
+    val method: String?,
+    val easyPay: EasyPay?,
+    val transfer: String?,
+    val paymentMethodKey: String?,
+) {
+    companion object {
+        fun fromJson(jsonObject: JSONObject): SelectedPaymentMethod {
+            val type = jsonObject.getString("type")
+            val method = runCatching {
+                jsonObject.getString("method")
+            }.getOrNull()
+            val easyPay = runCatching {
+                val provider = jsonObject.getJSONObject("easyPay").getString("provider")
+                EasyPay(provider)
+            }.getOrNull()
+            val transfer = runCatching {
+                jsonObject.getString("transfer")
+            }.getOrNull()
+            val paymentMethodKey = runCatching {
+                jsonObject.getString("paymentMethodKey")
+            }.getOrNull()
+
+            return SelectedPaymentMethod(type, method, easyPay, transfer, paymentMethodKey)
+        }
+    }
+}
+
+data class EasyPay(
+    val provider: String?,
+)
+
+data class Transfer(
+    val provider: String?,
+)

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/SelectedPaymentMethod.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/SelectedPaymentMethod.kt
@@ -1,6 +1,5 @@
 package com.tosspayments.paymentsdk.model
 
-import android.util.Log
 import org.json.JSONObject
 
 data class SelectedPaymentMethod(

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/TossPaymentResult.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/model/TossPaymentResult.kt
@@ -14,6 +14,6 @@ sealed interface TossPaymentResult {
     ) : TossPaymentResult, Parcelable
 
     @Parcelize
-    class Fail(val errorCode: String, val errorMessage: String, val orderId: String) :
+    class Fail(val errorCode: String, val errorMessage: String, val orderId: String?) :
         TossPaymentResult, Parcelable
 }

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/PaymentMethod.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/PaymentMethod.kt
@@ -20,6 +20,7 @@ class PaymentMethod(context: Context, attrs: AttributeSet? = null) :
         internal const val EVENT_NAME_CUSTOM_REQUESTED = "customRequest"
         internal const val EVENT_NAME_CUSTOM_METHOD_SELECTED = "customPaymentMethodSelect"
         internal const val EVENT_NAME_CUSTOM_METHOD_UNSELECTED = "customPaymentMethodUnselect"
+        internal const val EVENT_NAME_CHANGE_PAYMENT_METHOD = "changePaymentMethod"
 
         internal const val MESSAGE_NOT_RENDERED =
             "PaymentMethod is not rendered. Call 'renderPaymentMethods' method first."

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/PaymentWidgetContainer.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/PaymentWidgetContainer.kt
@@ -88,7 +88,7 @@ sealed class PaymentWidgetContainer(context: Context, attrs: AttributeSet? = nul
         appendWidgetRenderScript: StringBuilder.() -> StringBuilder
     ) {
         val paymentWidgetConstructor =
-            "PaymentWidget('$clientKey', '$customerKey', {'brandpay':{'redirectUrl':'${redirectUrl.orEmpty()}'}})"
+            "PaymentWidget('$clientKey', '$customerKey', 'payment-widget-android', {'brandpay':{'redirectUrl':'${redirectUrl.orEmpty()}'}})"
 
         val renderMethodScript = StringBuilder()
             .appendLine("var paymentWidget = $paymentWidgetConstructor;")

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/PaymentWidgetContainer.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/PaymentWidgetContainer.kt
@@ -13,6 +13,7 @@ import com.tosspayments.paymentsdk.R
 import com.tosspayments.paymentsdk.extension.startSchemeIntent
 import com.tosspayments.paymentsdk.interfaces.PaymentWidgetJavascriptInterface
 import com.tosspayments.paymentsdk.model.PaymentWidgetStatusListener
+import com.tosspayments.paymentsdk.model.TossPaymentResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -132,6 +133,12 @@ sealed class PaymentWidgetContainer(context: Context, attrs: AttributeSet? = nul
                     }
                 }
             }
+        }
+    }
+
+    internal fun onFail(fail: TossPaymentResult.Fail) {
+        CoroutineScope(Dispatchers.Main).launch {
+            statusListener?.onFail(fail)
         }
     }
 

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/TossPaymentView.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/TossPaymentView.kt
@@ -128,7 +128,7 @@ class TossPaymentView(context: Context, attrs: AttributeSet? = null) :
             paymentWebView = findViewById<PaymentWebView>(R.id.webview_payment).apply {
                 addJavascriptInterface(object : PaymentJavascriptInterface {
                     @JavascriptInterface
-                    fun error(errorCode: String, message: String, orderId: String) {
+                    fun error(errorCode: String, message: String, orderId: String?) {
                         callback?.onFailed(
                             TossPaymentResult.Fail(
                                 errorCode = errorCode,


### PR DESCRIPTION
1. getSelectedPaymentMethod 메서드 추가
    - renderPaymentMethods 이후, 사용자가 선택한 결제 수단을 반환
2. PaymentWidgetAndroidSDK.error 추가
    - PaymentWidgetActivity에서 발생하는 각종 validation error (예: 카드사 선택안함, api_key 오류) 처리
