### PR TITLE
브랜드페이 생체인증 SDK 통합

### DIFF
--- a/brandpay-auth/build.gradle
+++ b/brandpay-auth/build.gradle
@@ -1,0 +1,91 @@
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'kotlin-kapt'
+    id 'maven-publish'
+}
+
+
+android {
+    compileSdk 33
+
+    defaultConfig {
+        minSdk 21
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    file("versions.properties").withInputStream {
+        def props = new Properties()
+        props.load(it)
+        props.forEach { key, value ->
+            ext[key] = value
+        }
+    }
+
+
+    buildTypes {
+        debug {
+            buildConfigField "String", "MODULE_VERSION_NAME", "\"${brandPayAuth}\""
+
+            minifyEnabled false
+            shrinkResources false
+        }
+
+        release {
+            buildConfigField "String", "MODULE_VERSION_NAME", "\"${brandPayAuth}\""
+
+            minifyEnabled true
+            shrinkResources false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+        }
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId = 'com.github.tosspayments'
+                artifactId = 'brandpay-auth'
+                version = getBrandpayAuthVersion() as String
+            }
+        }
+    }
+}
+
+def getBrandpayAuthVersion() {
+    def properties = new Properties()
+    file('version.properties').withInputStream {
+        properties.load(it)
+    }
+    return properties.getProperty('brandPayAuth')
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.2.0'
+
+    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation "androidx.biometric:biometric:1.1.0"
+    implementation "androidx.security:security-crypto:1.1.0-alpha06"
+
+    testImplementation 'junit:junit:4.+'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+}

--- a/brandpay-auth/build.gradle
+++ b/brandpay-auth/build.gradle
@@ -72,7 +72,7 @@ afterEvaluate {
 
 def getBrandpayAuthVersion() {
     def properties = new Properties()
-    file('version.properties').withInputStream {
+    file('versions.properties').withInputStream {
         properties.load(it)
     }
     return properties.getProperty('brandPayAuth')

--- a/brandpay-auth/proguard-rules.pro
+++ b/brandpay-auth/proguard-rules.pro
@@ -1,0 +1,41 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+-dontshrink
+-dontobfuscate
+
+-keep class com.tosspayments.android.auth.interfaces.BrandPayAuthWebManager {
+    *;
+}
+
+-keep class com.tosspayments.android.auth.interfaces.BrandPayAuthWebManager$Companion { *;}
+
+-keep class com.tosspayments.android.auth.persistences.BrandPayUtilPreference { *;}
+
+-keep class com.tosspayments.android.auth.utils.BioMetricUtil { *;}
+
+-keep class android.hardware.biometrics.BiometricManager { *;}
+
+-keep class com.tosspayments.android.auth.utils.BrandPayAuthManager {
+    *;
+}
+
+-keep class com.tosspayments.android.auth.interfaces.BrandPayAuthWebManager$Callback { *;}

--- a/brandpay-auth/src/androidTest/java/com/tosspayments/android/auth/ExampleInstrumentedTest.kt
+++ b/brandpay-auth/src/androidTest/java/com/tosspayments/android/auth/ExampleInstrumentedTest.kt
@@ -1,0 +1,24 @@
+package com.tosspayments.android.auth
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.*
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class ExampleInstrumentedTest {
+    @Test
+    fun useAppContext() {
+        // Context of the app under test.
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        assertEquals("com.tosspayments.android.auth", appContext.packageName)
+    }
+}

--- a/brandpay-auth/src/main/AndroidManifest.xml
+++ b/brandpay-auth/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.tosspayments.android.auth">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+
+    <application>
+    </application>
+
+</manifest>

--- a/brandpay-auth/src/main/java/com/tosspayments/android/auth/interfaces/BrandPayAuthWebManager.kt
+++ b/brandpay-auth/src/main/java/com/tosspayments/android/auth/interfaces/BrandPayAuthWebManager.kt
@@ -1,0 +1,227 @@
+package com.tosspayments.android.auth.interfaces
+
+import android.annotation.SuppressLint
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import androidx.biometric.BiometricPrompt
+import androidx.fragment.app.FragmentActivity
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.annotations.SerializedName
+import com.tosspayments.android.auth.model.ErrorCode
+import com.tosspayments.android.auth.utils.BioMetricUtil
+import com.tosspayments.android.auth.utils.BrandPayAuthManager
+import java.lang.ref.WeakReference
+
+class BrandPayAuthWebManager(activity: FragmentActivity) {
+    companion object {
+        private const val JAVASCRIPT_INTERFACE_NAME = "ConnectPayAuth"
+    }
+
+    interface Callback {
+        fun onPostScript(script: String)
+    }
+
+    private val authJavascriptInterface = BrandPayAuthJavascriptInterface(activity)
+
+    var callback: Callback? = null
+        set(value) {
+            authJavascriptInterface.callback = value
+            field = value
+        }
+
+    @SuppressLint("JavascriptInterface")
+    fun addJavascriptInterface(webView: WebView) {
+        webView.addJavascriptInterface(
+            authJavascriptInterface,
+            JAVASCRIPT_INTERFACE_NAME
+        )
+    }
+
+    private class BrandPayAuthJavascriptInterface(activity: FragmentActivity) {
+        private val gson = Gson()
+
+        private var weakActivity: WeakReference<FragmentActivity> = WeakReference(activity)
+
+        var callback: Callback? = null
+
+        @JavascriptInterface
+        fun postMessage(message: String) {
+            weakActivity.get()?.let { activity ->
+                kotlin.runCatching {
+                    val jsonObj: JsonObject? = Gson().fromJson(message, JsonObject::class.java)
+                    val name = jsonObj?.get("name")?.asString
+                    val params: JsonObject? = jsonObj?.getAsJsonObject("params")
+                    val onSuccess = params?.get("onSuccess")?.asString
+                    val onError = params?.get("onError")?.asString
+
+                    when (name) {
+                        "getAppInfo" -> getAppInfo(activity, onSuccess)
+                        "getBiometricAuthMethods" -> {
+                            getBiometricAuthMethods(activity, onSuccess)
+                        }
+                        "verifyBiometricAuth" -> {
+                            verifyBiometricAuth(
+                                activity,
+                                params?.get("modulus")?.asString.orEmpty(),
+                                params?.get("exponent")?.asString.orEmpty(),
+                                onSuccess,
+                                onError
+                            )
+                        }
+                        "hasBiometricAuth" -> {
+                            hasBiometricAuth(activity, onSuccess)
+                        }
+                        "registerBiometricAuth" -> {
+                            registerBiometricAuth(
+                                activity,
+                                params?.get("biometricToken")?.asString.orEmpty(),
+                                onSuccess,
+                                onError
+                            )
+                        }
+                        "unregisterBiometricAuth" -> {
+                            unregisterBiometricAuth(
+                                activity,
+                                onSuccess,
+                                onError
+                            )
+                        }
+                        else -> {
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun getAppInfo(activity: FragmentActivity, onSuccess: String?) {
+            val appInfo = try {
+                gson.toJson(BrandPayAuthManager.getAppInfo(activity))
+            } catch (e: Exception) {
+                ""
+            }
+
+            postOnSuccess(onSuccess, appInfo)
+        }
+
+        private fun getBiometricAuthMethods(
+            activity: FragmentActivity,
+            onSuccess: String?
+        ) {
+            val methods = BrandPayAuthManager.getBiometricAuthMethods(activity)
+
+            if (methods.isEmpty()) {
+                postOnSuccess(onSuccess, "")
+            } else {
+                postOnSuccess(onSuccess, methods)
+            }
+        }
+
+        private fun verifyBiometricAuth(
+            activity: FragmentActivity,
+            modulus: String,
+            exponent: String,
+            onSuccess: String?,
+            onError: String?
+        ) {
+            BrandPayAuthManager.requestBioMetricAuth(activity,
+                modulus,
+                exponent,
+                {
+                    postOnSuccess(onSuccess, it)
+                },
+                { code, message ->
+                    postOnError(onError, code, message)
+                })
+        }
+
+        private fun hasBiometricAuth(
+            activity: FragmentActivity,
+            onSuccess: String?
+        ) {
+            postOnSuccess(
+                onSuccess,
+                BrandPayAuthManager.hasBioMetricAuth(activity).toString()
+            )
+        }
+
+        private fun registerBiometricAuth(
+            activity: FragmentActivity,
+            token: String,
+            onSuccess: String?,
+            onError: String?
+        ) {
+            if (token.isBlank()) {
+                postOnError(onError, ErrorCode.BIOMETRIC_INVALID, "Token을 확인해주세요.")
+            } else {
+                BioMetricUtil.requestAuth(activity,
+                    object : BiometricPrompt.AuthenticationCallback() {
+                        override fun onAuthenticationError(
+                            errorCode: Int,
+                            errString: CharSequence
+                        ) {
+                            when (errorCode) {
+                                BiometricPrompt.ERROR_NEGATIVE_BUTTON, BiometricPrompt.ERROR_USER_CANCELED -> {
+                                    postOnError(onError, ErrorCode.BIOMETRIC_CANCELED)
+                                }
+                                else -> {}
+                            }
+                        }
+
+                        override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                            BrandPayAuthManager.registerBiometricAuth(activity, token,
+                                {
+                                    postOnSuccess(onSuccess, true.toString())
+                                }, { code, message ->
+                                    postOnError(onError, code, message)
+                                })
+                        }
+                    })
+            }
+        }
+
+        private fun unregisterBiometricAuth(
+            activity: FragmentActivity,
+            onSuccess: String?,
+            onError: String?
+        ) {
+            BrandPayAuthManager.unregisterBiometricAuth(activity,
+                {
+                    postOnSuccess(onSuccess, "")
+                },
+                { code, message ->
+                    postOnError(onError, code, message)
+                })
+        }
+
+        private fun postOnSuccess(onSuccess: String?, data: String?) {
+            postScript("javascript:$onSuccess('${data.orEmpty()}');")
+        }
+
+        private fun postOnError(onError: String?, errorCode: ErrorCode, message: String = "") {
+            postScript(
+                "javascript:$onError('${
+                    gson.toJson(
+                        AuthError(
+                            errorCode.name,
+                            "${errorCode.message}$message"
+                        )
+                    )
+                }');"
+            )
+        }
+
+        private fun postScript(script: String?) {
+            weakActivity.get()?.runOnUiThread {
+                callback?.onPostScript(script.orEmpty())
+            }
+        }
+    }
+
+    private class AuthError(
+        @SerializedName("code")
+        val code: String,
+        @SerializedName("message")
+        val message: String
+    )
+}

--- a/brandpay-auth/src/main/java/com/tosspayments/android/auth/model/AppInfo.kt
+++ b/brandpay-auth/src/main/java/com/tosspayments/android/auth/model/AppInfo.kt
@@ -1,0 +1,13 @@
+package com.tosspayments.android.auth.model
+
+import com.google.gson.annotations.SerializedName
+import com.tosspayments.android.auth.BuildConfig
+
+data class AppInfo(
+    @SerializedName("app_id")
+    val app_id: String,
+    @SerializedName("sdk_version")
+    val sdkVersion: String = BuildConfig.MODULE_VERSION_NAME,
+    @SerializedName("os")
+    val os: String = "android"
+)

--- a/brandpay-auth/src/main/java/com/tosspayments/android/auth/model/ErrorCode.kt
+++ b/brandpay-auth/src/main/java/com/tosspayments/android/auth/model/ErrorCode.kt
@@ -1,0 +1,5 @@
+package com.tosspayments.android.auth.model
+
+enum class ErrorCode(val message: String) {
+    BIOMETRIC_CANCELED("생체인증 취소."), BIOMETRIC_INVALID("생체인증 유효하지 않음."), BIOMETRIC_FAILED("생체인증 실패.")
+}

--- a/brandpay-auth/src/main/java/com/tosspayments/android/auth/persistences/BrandPayUtilPreference.kt
+++ b/brandpay-auth/src/main/java/com/tosspayments/android/auth/persistences/BrandPayUtilPreference.kt
@@ -1,0 +1,51 @@
+package com.tosspayments.android.auth.persistences
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import androidx.security.crypto.MasterKeys
+
+internal class BrandPayUtilPreference private constructor(context: Context) {
+    private val preference: SharedPreferences = EncryptedSharedPreferences.create(
+        context,
+        "tossBrandPayUtilPreference",
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            MasterKey.Builder(context)
+                .setKeyGenParameterSpec(MasterKeys.AES256_GCM_SPEC)
+                .build()
+        } else {
+            MasterKey.Builder(context).build()
+        },
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    companion object {
+        private lateinit var instance: BrandPayUtilPreference
+
+        fun getInstance(context: Context): BrandPayUtilPreference {
+            return if (Companion::instance.isInitialized) {
+                instance
+            } else {
+                BrandPayUtilPreference(context).also {
+                    instance = it
+                }
+            }
+        }
+    }
+
+    @SuppressLint("CommitPrefEdits")
+    fun putString(key: String, value: String) {
+        preference.edit {
+            putString(key, value)
+        }
+    }
+
+    fun getString(key: String): String? {
+        return preference.getString(key, null)
+    }
+}

--- a/brandpay-auth/src/main/java/com/tosspayments/android/auth/utils/BioMetricUtil.kt
+++ b/brandpay-auth/src/main/java/com/tosspayments/android/auth/utils/BioMetricUtil.kt
@@ -1,0 +1,151 @@
+package com.tosspayments.android.auth.utils
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import com.tosspayments.android.auth.persistences.BrandPayUtilPreference
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.RSAPublicKeySpec
+import javax.crypto.Cipher
+
+internal object BioMetricUtil {
+    private const val KEY_TOKEN = "brandPayAuthKeyToken"
+
+    private enum class BioMetricType {
+        FACE, FINGERPRINT
+    }
+
+    private lateinit var preference: BrandPayUtilPreference
+
+    fun getBiometricAuthMethods(context: Context): List<String> {
+        return when (BiometricManager.from(context)
+            .canAuthenticate()) {
+            BiometricManager.BIOMETRIC_SUCCESS -> {
+                val bioMetricTypes = mutableSetOf<BioMetricType>()
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)) {
+                        bioMetricTypes.add(BioMetricType.FINGERPRINT)
+                    }
+
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+                        && context.packageManager.hasSystemFeature(PackageManager.FEATURE_FACE)
+                    ) {
+                        bioMetricTypes.add(BioMetricType.FACE)
+                    }
+                } else {
+                    bioMetricTypes.add(BioMetricType.FINGERPRINT)
+                }
+
+                bioMetricTypes.map { it.name }
+            }
+            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> {
+                throw Exception("생체인증을 지원하지 않는 기기입니다.")
+            }
+            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {
+                throw Exception("등록된 생체인증이 없습니다.")
+            }
+            else -> {
+                throw Exception("생체인증을 사용할 수 없습니다.")
+            }
+        }
+    }
+
+    fun requestAuth(
+        activity: FragmentActivity,
+        callback: BiometricPrompt.AuthenticationCallback
+    ) {
+        activity.runOnUiThread {
+            BiometricPrompt(activity, ContextCompat.getMainExecutor(activity), callback)
+                .authenticate(
+                    BiometricPrompt.PromptInfo.Builder()
+                        .setTitle("생체 정보로 인증해주세요")
+                        .setNegativeButtonText("취소")
+                        .build()
+                )
+        }
+    }
+
+    fun hasBioMetricAuth(context: Context): Boolean {
+        if (!::preference.isInitialized) {
+            preference = BrandPayUtilPreference.getInstance(context)
+        }
+
+        return !preference.getString(KEY_TOKEN).isNullOrBlank()
+    }
+
+    @Throws
+    fun getBioMetricAuth(context: Context, modulus: String, exponent: String): String {
+        if (!::preference.isInitialized) {
+            preference = BrandPayUtilPreference.getInstance(context)
+        }
+
+        try {
+            return rsaEncrypt(preference.getString(KEY_TOKEN).orEmpty(), modulus, exponent)
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    fun registerBioMetricAuth(context: Context, token: String?): Boolean {
+        if (!::preference.isInitialized) {
+            preference = BrandPayUtilPreference.getInstance(context)
+        }
+
+        return try {
+            preference.putString(KEY_TOKEN, token.orEmpty())
+            true
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    fun unregisterBioMetricAuth(context: Context) {
+        if (!::preference.isInitialized) {
+            preference = BrandPayUtilPreference.getInstance(context)
+        }
+
+        try {
+            preference.putString(KEY_TOKEN, "")
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    private fun getCipher(
+        mode: Int,
+        modulus: String,
+        exponent: String,
+        transformation: String,
+        algorithm: String
+    ): Cipher {
+        val cipher: Cipher = Cipher.getInstance(transformation)
+        val keySpec = RSAPublicKeySpec(BigInteger(modulus, 16), BigInteger(exponent, 16))
+        val publicKey: PublicKey = KeyFactory.getInstance(algorithm).generatePublic(keySpec)
+
+        cipher.init(mode, publicKey)
+        return cipher
+    }
+
+    private fun getRsaEncryptCipher(
+        modulus: String,
+        exponent: String
+    ): Cipher {
+        return getCipher(Cipher.ENCRYPT_MODE, modulus, exponent, "RSA/ECB/PKCS1Padding", "RSA")
+    }
+
+    private fun rsaEncrypt(source: String, modulus: String, exponent: String): String {
+        val cipher = getRsaEncryptCipher(modulus, exponent)
+        return cipher.doFinal(source.toByteArray()).toHexString()
+    }
+
+    @ExperimentalUnsignedTypes
+    private fun ByteArray.toHexString() =
+        asUByteArray().joinToString("") { it.toString(16).padStart(2, '0') }
+}

--- a/brandpay-auth/src/main/java/com/tosspayments/android/auth/utils/BrandPayAuthManager.kt
+++ b/brandpay-auth/src/main/java/com/tosspayments/android/auth/utils/BrandPayAuthManager.kt
@@ -1,0 +1,138 @@
+package com.tosspayments.android.auth.utils
+
+import android.content.Context
+import androidx.biometric.BiometricPrompt
+import androidx.fragment.app.FragmentActivity
+import com.google.gson.Gson
+import com.tosspayments.android.auth.model.AppInfo
+import com.tosspayments.android.auth.model.ErrorCode
+
+object BrandPayAuthManager {
+    @JvmStatic
+    fun getAppInfo(context: Context): AppInfo {
+        return AppInfo(context.packageName)
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun requestBioMetricAuth(
+        activity: FragmentActivity,
+        modulus: String,
+        exponent: String,
+        onSuccess: ((String) -> Unit)? = null,
+        onError: ((ErrorCode, String) -> Unit)? = null
+    ) {
+        fun invokeOnSuccess(data: String) {
+            activity.runOnUiThread {
+                onSuccess?.invoke(data)
+            }
+        }
+
+        fun invokeOnError(errorCode: ErrorCode, message: String = "") {
+            activity.runOnUiThread {
+                onError?.invoke(errorCode, "${errorCode.message}$message")
+            }
+        }
+
+        try {
+            BioMetricUtil.getBiometricAuthMethods(activity)
+        } catch (e: Exception) {
+            invokeOnError(ErrorCode.BIOMETRIC_FAILED, e.message.orEmpty())
+            return
+        }
+
+        if (!BioMetricUtil.hasBioMetricAuth(activity)) {
+            invokeOnError(ErrorCode.BIOMETRIC_INVALID, "생체인증이 설정되지 않았습니다.")
+            return
+        }
+
+        BioMetricUtil.requestAuth(activity,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationError(
+                    errorCode: Int,
+                    errString: CharSequence
+                ) {
+                    when (errorCode) {
+                        BiometricPrompt.ERROR_NEGATIVE_BUTTON, BiometricPrompt.ERROR_USER_CANCELED -> {
+                            invokeOnError(ErrorCode.BIOMETRIC_CANCELED)
+                        }
+                        else -> {}
+                    }
+                }
+
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    try {
+                        invokeOnSuccess(
+                            BioMetricUtil.getBioMetricAuth(
+                                activity,
+                                modulus,
+                                exponent
+                            )
+                        )
+                    } catch (e: Exception) {
+                        invokeOnError(ErrorCode.BIOMETRIC_FAILED, e.message.orEmpty())
+                    }
+                }
+            })
+    }
+
+    @JvmStatic
+    fun getBiometricAuthMethods(activity: FragmentActivity): String {
+        return Gson().toJson(
+            try {
+                BioMetricUtil.getBiometricAuthMethods(activity)
+            } catch (e: Exception) {
+                emptyList<String>()
+            }
+        )
+    }
+
+    @JvmStatic
+    fun hasBioMetricAuth(activity: FragmentActivity): Boolean {
+        return BioMetricUtil.hasBioMetricAuth(activity)
+    }
+
+    @JvmStatic
+    fun registerBiometricAuth(
+        activity: FragmentActivity,
+        token: String?,
+        onSuccess: (() -> Unit),
+        onError: ((ErrorCode, String) -> Unit)
+    ) {
+        kotlin.runCatching {
+
+            BioMetricUtil.registerBioMetricAuth(
+                activity,
+
+                token.orEmpty()
+            )
+        }.onSuccess {
+            activity.runOnUiThread {
+                onSuccess.invoke()
+            }
+        }.onFailure {
+            activity.runOnUiThread {
+                onError.invoke(ErrorCode.BIOMETRIC_FAILED, it.message.orEmpty())
+            }
+        }
+    }
+
+    @JvmStatic
+    fun unregisterBiometricAuth(
+        activity: FragmentActivity,
+        onSuccess: (() -> Unit),
+        onError: ((ErrorCode, String) -> Unit)
+    ) {
+        kotlin.runCatching {
+            BioMetricUtil.unregisterBioMetricAuth(activity)
+        }.onSuccess {
+            activity.runOnUiThread {
+                onSuccess.invoke()
+            }
+        }.onFailure {
+            activity.runOnUiThread {
+                onError.invoke(ErrorCode.BIOMETRIC_FAILED, it.message.orEmpty())
+            }
+        }
+    }
+}

--- a/brandpay-auth/src/main/java/com/tosspayments/android/auth/utils/CommonUtils.kt
+++ b/brandpay-auth/src/main/java/com/tosspayments/android/auth/utils/CommonUtils.kt
@@ -1,0 +1,169 @@
+package com.tosspayments.android.auth.utils
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.PorterDuff
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.os.ResultReceiver
+import android.util.TypedValue
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import androidx.core.content.getSystemService
+import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.postDelayed
+import kotlin.math.roundToInt
+
+object CommonUtils {
+    private const val DEFAULT_SOFT_INPUT_DELAY = 350L
+
+    fun getScreenWidth(context: Context): Int {
+        return context.resources.displayMetrics.widthPixels
+    }
+
+    fun getScreenHeight(context: Context): Int {
+        return context.resources.displayMetrics.heightPixels
+    }
+
+    fun getStatusBarHeight(context: Context): Int {
+        var result = 0
+        val resourceId = context.resources.getIdentifier("status_bar_height", "dimen", "android")
+        if (resourceId > 0) {
+            result = context.resources.getDimensionPixelSize(resourceId)
+        }
+        return result
+    }
+
+    fun getAppHeight(context: Context): Int {
+        return getScreenHeight(context) - getStatusBarHeight(context)
+    }
+
+    fun convertDipToPx(dip: Number, context: Context): Int {
+        return dip.toFloat().takeUnless { it > 0f }?.toInt()
+            ?: TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                dip.toFloat(),
+                context.resources.displayMetrics
+            ).toInt().coerceAtLeast(1)
+    }
+
+    fun convertSpToPx(sp: Number, context: Context): Int {
+        return sp.toFloat().takeUnless { it > 0f }?.toInt()
+            ?: TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                sp.toFloat(),
+                context.resources.displayMetrics
+            ).toInt().coerceAtLeast(1)
+    }
+
+    fun convertPxToDip(px: Number, context: Context): Float {
+        return px.toFloat() / context.resources.displayMetrics.density
+    }
+
+    fun convertPxToSp(px: Number, context: Context): Int {
+        return (px.toFloat() / context.resources.displayMetrics.scaledDensity).toInt()
+    }
+
+    fun convertPercentToHex(percent: Int) = (0xff * percent / 100f).roundToInt()
+
+    fun tint(icon: Drawable, color: Int, mode: PorterDuff.Mode = PorterDuff.Mode.SRC_IN): Drawable {
+        val drawable = DrawableCompat.wrap(icon).mutate()
+        DrawableCompat.setTintList(drawable, ColorStateList.valueOf(color))
+        DrawableCompat.setTintMode(drawable, mode)
+        return drawable
+    }
+
+    fun tint(
+        icon: Drawable,
+        color: ColorStateList?,
+        mode: PorterDuff.Mode = PorterDuff.Mode.SRC_IN
+    ): Drawable {
+        val drawable = DrawableCompat.wrap(icon).mutate()
+        DrawableCompat.setTintList(drawable, color)
+        DrawableCompat.setTintMode(drawable, mode)
+        return drawable
+    }
+
+    fun hideSoftInputAndClearFocus(editText: EditText?) {
+        hideSoftInput(editText)
+        editText?.clearFocus()
+    }
+
+    fun hideSoftInputAndClearFocus(vararg editTexts: EditText?) {
+        for (editText in editTexts) hideSoftInputAndClearFocus(editText)
+    }
+
+    fun hideSoftInput(view: View?) {
+        if (view == null) {
+            return
+        }
+        val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        imm?.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+
+    /**
+     * @see [im.toss.uikit.widget.dialog.NeatBottomSheetDialog] dismiss animation 250ms + 100ms (buffer)을 기준으로 기본값 설정
+     */
+    fun showSoftInputWithDelay(view: View?, delayMillis: Long = DEFAULT_SOFT_INPUT_DELAY) {
+        if (view == null) {
+            return
+        }
+        view.postDelayed(delayMillis) { showSoftInput(view) }
+    }
+
+    fun showSoftInput(view: View?) {
+        if (view == null) {
+            return
+        }
+
+        view.requestFocus()
+        val imm: InputMethodManager = view.context.getSystemService() ?: return
+        val targetView = view.findFocus() ?: view
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            targetView.doOnWindowFocused {
+                imm.showSoftInput(targetView, 0)
+                if (targetView is EditText) {
+                    targetView.setSelection(targetView.length())
+                }
+            }
+            return
+        }
+
+        try {
+            // showSoftInputUnchecked is blocked from Android 10
+            // https://developer.android.com/about/versions/10/non-sdk-q#new-blocked
+            val showSoftInputUnchecked = InputMethodManager::class.java.getMethod(
+                "showSoftInputUnchecked",
+                Int::class.javaPrimitiveType,
+                ResultReceiver::class.java
+            )
+            showSoftInputUnchecked.isAccessible = true
+            showSoftInputUnchecked.invoke(imm, 0, null)
+        } catch (e: Exception) {
+            imm.showSoftInput(targetView, 0)
+        } finally {
+            if (targetView is EditText) {
+                targetView.setSelection(targetView.length())
+            }
+        }
+    }
+
+    private inline fun View.doOnWindowFocused(crossinline action: (view: View) -> Unit) {
+        if (hasWindowFocus()) {
+            action(this)
+        } else {
+            viewTreeObserver.addOnWindowFocusChangeListener(object :
+                ViewTreeObserver.OnWindowFocusChangeListener {
+                override fun onWindowFocusChanged(hasFocus: Boolean) {
+                    if (hasFocus) {
+                        viewTreeObserver.removeOnWindowFocusChangeListener(this)
+                        action(this@doOnWindowFocused)
+                    }
+                }
+            })
+        }
+    }
+}

--- a/brandpay-auth/src/main/res/values/colors.xml
+++ b/brandpay-auth/src/main/res/values/colors.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+
+    <color name="blue_500">#ff3182f6</color>
+    <color name="blue_700">#ff1b64da</color>
+
+    <color name="grey_300">#ffd1d6db</color>
+    <color name="grey_500">#ff8b95a1</color>
+    <color name="grey_800">#ff333d4b</color>
+    <color name="grey_900">#ff191f28</color>
+
+    <color name="inverse_grey_900">#ffffff</color>
+
+    <color name="grey_opacity_900">#e8020913</color>
+</resources>

--- a/brandpay-auth/src/main/res/values/strings.xml
+++ b/brandpay-auth/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="confirm">확인</string>
+</resources>

--- a/brandpay-auth/src/main/res/values/themes.xml
+++ b/brandpay-auth/src/main/res/values/themes.xml
@@ -1,0 +1,3 @@
+<resources>
+
+</resources>

--- a/brandpay-auth/src/test/java/com/tosspayments/android/auth/ExampleUnitTest.kt
+++ b/brandpay-auth/src/test/java/com/tosspayments/android/auth/ExampleUnitTest.kt
@@ -1,0 +1,17 @@
+package com.tosspayments.android.auth
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/brandpay-auth/versions.properties
+++ b/brandpay-auth/versions.properties
@@ -1,0 +1,2 @@
+#Mon Jun 07 12:59:11 KST 2021
+brandPayAuth=0.2.0

--- a/paymentsdk/build.gradle
+++ b/paymentsdk/build.gradle
@@ -67,6 +67,7 @@ afterEvaluate {
 }
 
 dependencies {
+    api project(':brandpay-auth')
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.0'

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/activity/TossPaymentActivity.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/activity/TossPaymentActivity.kt
@@ -3,7 +3,9 @@ package com.tosspayments.paymentsdk.activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
+import com.tosspayments.android.auth.interfaces.BrandPayAuthWebManager
 import com.tosspayments.paymentsdk.R
 import com.tosspayments.paymentsdk.TossPayments
 import com.tosspayments.paymentsdk.interfaces.TossPaymentCallback
@@ -45,6 +47,14 @@ internal class TossPaymentActivity : AppCompatActivity() {
     }
 
     private var viewPayment: TossPaymentView? = null
+
+    private val brandPayAuthWebManager = BrandPayAuthWebManager(this).apply {
+        callback = object : BrandPayAuthWebManager.Callback {
+            override fun onPostScript(script: String) {
+                findViewById<WebView>(R.id.webview_payment).loadUrl(script)
+            }
+        }
+    }
 
     private val paymentCallback: TossPaymentCallback
         get() = object : TossPaymentCallback {
@@ -88,6 +98,7 @@ internal class TossPaymentActivity : AppCompatActivity() {
     private fun initViews() {
         viewPayment = findViewById<TossPaymentView>(R.id.payment_view).apply {
             callback = paymentCallback
+            addJavascriptInterface(brandPayAuthWebManager)
         }
     }
 

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/activity/TossPaymentsWebActivity.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/activity/TossPaymentsWebActivity.kt
@@ -6,11 +6,13 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.webkit.JavascriptInterface
 import androidx.appcompat.app.AppCompatActivity
+import com.tosspayments.android.auth.interfaces.BrandPayAuthWebManager
 import com.tosspayments.paymentsdk.R
 import com.tosspayments.paymentsdk.interfaces.PaymentJavascriptInterface
 import com.tosspayments.paymentsdk.model.Constants
 import com.tosspayments.paymentsdk.view.PaymentWebView
 import com.tosspayments.paymentsdk.view.PaymentWidgetContainer
+import org.json.JSONObject
 
 internal class TossPaymentsWebActivity : AppCompatActivity() {
     companion object {
@@ -22,6 +24,14 @@ internal class TossPaymentsWebActivity : AppCompatActivity() {
     }
 
     private lateinit var webView: PaymentWebView
+
+    private val brandPayAuthWebManager = BrandPayAuthWebManager(this).apply {
+        callback = object : BrandPayAuthWebManager.Callback {
+            override fun onPostScript(script: String) {
+                webView.loadUrl(script)
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,6 +56,8 @@ internal class TossPaymentsWebActivity : AppCompatActivity() {
                     handleSuccessResponse(response)
                 }
             }, PaymentWebView.INTERFACE_NAME_PAYMENT)
+
+            brandPayAuthWebManager.addJavascriptInterface(this)
         }
     }
 

--- a/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/TossPaymentView.kt
+++ b/paymentsdk/src/main/java/com/tosspayments/paymentsdk/view/TossPaymentView.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.webkit.*
 import android.widget.FrameLayout
+import com.tosspayments.android.auth.interfaces.BrandPayAuthWebManager
 import com.tosspayments.paymentsdk.R
 import com.tosspayments.paymentsdk.extension.startSchemeIntent
 import com.tosspayments.paymentsdk.interfaces.PaymentJavascriptInterface
@@ -173,6 +174,11 @@ class TossPaymentView(context: Context, attrs: AttributeSet? = null) :
 
             loadHtml(html, domain)
         }
+    }
+
+
+    internal fun addJavascriptInterface(brandPayAuthWebManager : BrandPayAuthWebManager) {
+        brandPayAuthWebManager.addJavascriptInterface(paymentWebView)
     }
 
     private fun requestPayment(paymentInfoPayload: String) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,3 +17,4 @@ dependencyResolutionManagement {
 rootProject.name = "TossPaymentSdk"
 include ':app'
 include ':paymentsdk'
+include ':brandpay-auth'


### PR DESCRIPTION
- brandpay-sdk-android 레포에서 관리하던 브랜드페이 생체인증 SDK 내부 코드를 이 레포로 이전
- 이제 이 레포에서 brandpay-auth 모듈 코드 관리 및 배포 진행

- ``` 
   implementation("com.github.tosspayments.payment-sdk-android:brandpay-auth:${version}")
   ``` 
    를 통해 브랜드페이 생체인증 SDK만 의존성 추가 가능

- 결제위젯 SDK는 버전 업만 하면 브랜드페이 생체인증 지원