### PR TITLE
fix(workspace): jitpack 빌드 환경에서는 local로만 빌드하도록 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,12 +61,20 @@ android {
     }
 }
 
+val isJitpackBuild = System.getenv("JITPACK_VERSION") != null
+
 dependencies {
     add("localImplementation", project(":paymentsdk"))
-    add(
-        "remoteImplementation",
-        "com.github.tosspayments:payment-sdk-android:${project.property("versionName")}"
-    )
+
+    // jitpack 에서 신규 버전 배포 전 빌드 시에는 모든 variant 에 대해 빌드하는데, 이 시점에는 신규 버전이 배포되지 않은 상태이기 때문에 local 로 빌드해 준다.
+    if (isJitpackBuild) {
+        add("implementation", project(":paymentsdk"))
+    } else {
+        add(
+            "remoteImplementation",
+            "com.github.tosspayments:payment-sdk-android:${project.property("versionName")}"
+        )
+    }
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)


### PR DESCRIPTION
## 변경사항
jitpack 빌드 시에는 모든 variant 가 빌드되는데, 신규 버전 빌드 시에는 project.property("versionName") 버전은 아직 배포되지 않은 상태이기 때문에 문제가 되어서, 이를 방지합니다.